### PR TITLE
Events and Game Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 utils/constants.py
 codes
 confidential.ini
+test.py

--- a/bot.py
+++ b/bot.py
@@ -1,10 +1,11 @@
+import re
 import asyncpg
 import discord
 import logging
 
 from context import BBContext
 from discord.ext import commands
-from typing import Callable, Dict, List, Set
+from typing import Callable, Dict, List, Optional, Set, Union
 from utils.constants import TABLE_LEADERBOARD
 
 
@@ -87,3 +88,15 @@ class BunkerBot(commands.Bot):
                       ON CONFLICT(user_id) \
                       DO UPDATE SET xp = {TABLE_LEADERBOARD}.xp + $2'
             await con.executemany(query, _data.items())
+
+    async def getch_member(self, guild: discord.Guild, user_id: int) -> Union[discord.Member, int]:
+        member = guild.get_member(user_id)
+        if member:
+            return member
+
+        try:
+            member = await guild.fetch_member(user_id)
+        except discord.HTTPException:
+            return user_id
+        else:
+            return member

--- a/cogs/auction.py
+++ b/cogs/auction.py
@@ -1,0 +1,14 @@
+import discord
+
+from bot import BunkerBot
+from context import BBContext
+from discord.ext import commands
+
+
+class auction(commands.Cog):
+    def __init__(self, bot: BunkerBot) -> None:
+        self.bot = bot
+
+
+def setup(bot: BunkerBot) -> None:
+    bot.add_cog(auction(bot))

--- a/cogs/auction.py
+++ b/cogs/auction.py
@@ -1,13 +1,220 @@
+from __future__ import annotations
+import asyncpg
 import discord
 
 from bot import BunkerBot
 from context import BBContext
+from datetime import datetime, timedelta
 from discord.ext import commands
+from typing import List, Optional
+from utils.constants import COINS
+from utils.converters import TimeConverter
+from utils.levels import LeaderboardPlayer
+from utils.views import EmbedViewPagination
+
+
+TABLE_AUCTION = 'events.auctions'
+TABLE_AUCTION_LOG = 'events.auctions_log'
+
+
+class AuctionItem:
+    __slots__ = ('id', 'name', '_current_bet', 'minimum_increment', 'active_till', 'current_holder')
+
+    def __init__(self, *, id: int, name: str, minimum_increment: int, active_till: datetime, current_bet: Optional[int], current_holder: Optional[int] = None) -> None:
+        self.id = id
+        self.name = name
+        self._current_bet = current_bet
+        self.minimum_increment = minimum_increment
+        self.active_till = active_till
+        self.current_holder = current_holder
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(**data)
+
+    @classmethod
+    async def fetch(cls, item_name: str, con: asyncpg.Connection) -> Optional[AuctionItem]:
+        query = f'SELECT id, name, current_bet, minimum_increment, active_till, current_holder FROM {TABLE_AUCTION} where name = $1'
+        row = await con.fetchrow(query, item_name)
+        if not row:
+            return None
+
+        return cls(**dict(row))
+
+    @property
+    def current_bet(self) -> int:
+        return self._current_bet or 0
+
+    @property
+    def next_bet(self) -> int:
+        return self.current_bet + self.minimum_increment
+
+    @property
+    def expires_in(self) -> str:
+        return discord.utils.format_dt(self.active_till)
+
+
+class AuctionPages(EmbedViewPagination):
+    def __init__(self, user_id: int, data: List[asyncpg.Record], *, bot: BunkerBot, guild: discord.Guild):
+        super().__init__(data, per_page=5)
+        self.user_id = user_id
+        self.bot = bot
+        self.guild = guild
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user.id == self.user_id # type: ignore
+
+    async def format_page(self, data: List[asyncpg.Record]) -> discord.Embed:
+        embed = discord.Embed(title='Goodies for auction').set_footer(text=f'{self.current_page}/{self.max_pages}')
+        for row in data:
+            item = AuctionItem.from_dict(dict(row))
+
+            if item.current_holder:
+                user = await self.bot.getch_member(self.guild, item.current_holder)
+                current_holder = user.name if isinstance(user, discord.Member) else user
+            else:
+                current_holder = 'No bet yet'                  
+
+            embed.add_field(name=f'**{item.name}**', value=f'\nMinimum next bet: {item.next_bet} {COINS}\nEnds on {item.expires_in}\n({current_holder}: {item.current_bet} {COINS})')
+        return embed
+
+
+class AuctionAddFlags(commands.FlagConverter, delimiter=' ', prefix='-'):
+    name: str = commands.flag(aliases=['n'])
+    increment: int = commands.flag(aliases=['i'])
+    time: TimeConverter = commands.flag(aliases=['t'])
+
+
+class AuctionUpdateFlags(AuctionAddFlags):
+    increment: Optional[int] = commands.flag(aliases=['i'])
+    time: Optional[TimeConverter] = commands.flag(aliases=['t'])
 
 
 class auction(commands.Cog):
     def __init__(self, bot: BunkerBot) -> None:
         self.bot = bot
+        self.enabled: bool = False
+
+    @commands.command()
+    @commands.cooldown(1, 60.0, commands.BucketType.member)
+    async def goodies(self, ctx: BBContext):
+
+        if not self.enabled:
+            return await ctx.send('There is no auction being conducted right now.')
+
+        con = await ctx.get_connection()
+        query = f'SELECT id, name, current_bet, minimum_increment, active_till, current_holder FROM {TABLE_AUCTION} WHERE active_till > $1'
+        rows = await con.fetch(query, discord.utils.utcnow())
+
+        if rows:    
+            view = AuctionPages(ctx.author.id, rows, bot=self.bot, guild=ctx.guild)
+            await view.start(ctx.channel)
+        else:
+            await ctx.send('No goodies available right now.')
+    
+    @commands.command()
+    @commands.cooldown(1, 60.0, commands.BucketType.member)
+    async def bet(self, ctx: BBContext, bet_amount: int, *, item_name: str):
+
+        if not self.enabled:
+            return await ctx.send('There is no auction being conducted right now.')
+            
+        con = await ctx.get_connection()
+        item = await AuctionItem.fetch(item_name, con)
+
+        if not item:
+            return await ctx.send(f'No item with name: **{item_name}** exists.')
+
+        if item.active_till < discord.utils.utcnow():
+            return await ctx.send(f'**{item_name}** is no longer accepting bets.')
+
+        if item.current_holder == ctx.author.id:
+            return await ctx.send('You already are the highest bidder.')
+
+        if bet_amount < item.next_bet:
+            return await ctx.send(f'You can not bet **{bet_amount}**. You need to bet at least **{item.next_bet}**.')
+
+        player = await LeaderboardPlayer.fetch(con, ctx.author)
+
+        if player.coins < bet_amount:
+            return await ctx.send(f'You only have **{player.coins}** {COINS} lol.')
+
+        query = f'INSERT INTO {TABLE_AUCTION_LOG}(user_id, item_id, bet_amount, time, item_name, old_bet, old_user_id) VALUES($1, $2, $3, $4, $5, $6, $7)'
+        await con.execute(query, ctx.author.id, item.id, bet_amount, discord.utils.utcnow(), item.name, item.current_bet, item.current_holder)
+        await ctx.tick()
+
+    @commands.group(name='auction')
+    @commands.has_guild_permissions(administrator=True)
+    async def _auction(self, ctx: BBContext):
+        pass
+
+    @_auction.command()
+    async def add(self, ctx: BBContext, *, flags: AuctionAddFlags):
+        con = await ctx.get_connection()
+        query = f'INSERT INTO {TABLE_AUCTION}(name, minimum_increment, active_till) VALUES($1, $2, $3)'
+
+        try:
+            await con.execute(query, flags.name, flags.increment, discord.utils.utcnow()  + timedelta(seconds=flags.time)) # type: ignore
+        except asyncpg.exceptions.UniqueViolationError:
+            await ctx.send(f'Auction item with name **{flags.name}** already exists')
+        else:
+            await ctx.tick()
+
+    @_auction.command()
+    async def remove(self, ctx: BBContext, *, item_name: str):
+        con = await ctx.get_connection()
+        query = f'DELETE FROM {TABLE_AUCTION} WHERE name = $1 RETURNING *'
+        row = await con.fetchrow(query, item_name)
+
+        if not row:
+            return await ctx.send(f'Auction item with name **{item_name}** does not exist.')
+
+        item = AuctionItem.from_dict(dict(row))
+
+        if item.current_holder:
+            user = await self.bot.getch_member(ctx.guild, item.current_holder)
+            current_holder = user.name if isinstance(user, discord.Member) else user
+        else:
+            current_holder = 'No bet yet'   
+
+        description = f'\nMinimum next bet: {item.next_bet} {COINS}\nEnds on {item.expires_in}\n({current_holder}: {item.current_bet} {COINS})'
+        embed = discord.Embed(title=f'Deleted: {row["name"]}', description=description)
+        await ctx.send(embed=embed)
+
+    @_auction.command()
+    async def update(self, ctx: BBContext, *, flags: AuctionUpdateFlags):
+        if not (flags.increment or flags.time):
+            return await ctx.send(f'You must either provide `-increment` or `-time`.')
+
+        columns = []
+        args = []
+
+        if flags.increment:
+            columns.append('minimum_increment')
+            args.append(flags.increment)
+
+        if flags.time:
+            columns.append('active_till')
+            args.append(discord.utils.utcnow()  + timedelta(seconds=flags.time)) # type: ignore
+
+        con = await ctx.get_connection()
+        cols = ', '.join(f'{col}=${i+2}' for i, col in enumerate(columns))
+        query = f'UPDATE {TABLE_AUCTION} SET {cols} WHERE name = $1'
+        args.insert(0, flags.name)
+        args.insert(0, query)
+        
+        val = await con.execute(*args)
+        if val == 'UPDATE 0':
+             await ctx.send(f'No auction item found with name: **{flags.name}**')
+        else:
+            await ctx.tick()
+
+    @_auction.command()
+    async def toggle(self, ctx: BBContext):
+        self.enabled = not self.enabled
+        e = 'enabled.' if self.enabled else 'disabled.'
+        await ctx.send(f'Auctions are now {e}')
+
 
 
 def setup(bot: BunkerBot) -> None:

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,5 +1,3 @@
-import re
-import asyncpg
 import discord
 
 from bot import BunkerBot
@@ -174,7 +172,7 @@ class events(commands.Cog):
 
         if player.level < 1:
             return await ctx.send('Coins can not be added to anyone below level 1')
-            
+
         await player.update(con, coins=coins)
         await ctx.tick()
 

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,0 +1,14 @@
+import discord
+
+from bot import BunkerBot
+from context import BBContext
+from discord.ext import commands
+
+
+class events(commands.Cog):
+    def __init__(self, bot: BunkerBot) -> None:
+        self.bot = bot
+
+
+def setup(bot: BunkerBot) -> None:
+    bot.add_cog(events(bot))

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,14 +1,182 @@
+import re
+import asyncpg
 import discord
 
 from bot import BunkerBot
 from context import BBContext
 from discord.ext import commands
+from typing import List, Optional
+from utils.constants import events_lounge, events_answers, events_participants, server_logs
+from utils.levels import LeaderboardPlayer
+
+
+WORD_SEARCH_REACTIONS = {
+    '1\N{variation selector-16}\N{combining enclosing keycap}': 'Hey {}, you have **one** word wrong.',
+    '2\N{variation selector-16}\N{combining enclosing keycap}': 'Hey {}, you have **two** words wrong.',
+    '\N{BLACK UP-POINTING DOUBLE TRIANGLE}': 'Hey {}, you have **three or more** words wrong.',
+    '\N{FIRST PLACE MEDAL}': 'Hey {}, you have got the **21** words!',
+    '\N{SECOND PLACE MEDAL}': 'Hey {}, you have got the **15** words!',
+    '\N{THIRD PLACE MEDAL}': 'Hey {}, you have got the **10** words!',
+}
 
 
 class events(commands.Cog):
     def __init__(self, bot: BunkerBot) -> None:
         self.bot = bot
+        self.listen_ws: bool = True # word search # TODO FALSE
+        self.listen_hman: bool = False # hangman
+        self.hangman_players: List[discord.Member] = []
 
+    @commands.command()
+    async def ea(self, ctx: BBContext, *, words: Optional[str] ='None'):
+        eventslounge = ctx.guild.get_channel(events_lounge)
+
+        if ctx.channel == eventslounge:
+            channel: discord.TextChannel = ctx.guild.get_channel(events_answers)
+            await channel.send(f'``` ```\n**Event Submission**\nUser: {ctx.author.mention} ({ctx.author.display_name})'
+                               f' \nUser ID: {ctx.author.id} \nSubmisson:\n{words}', allowed_mentions=discord.AllowedMentions.none())
+            await ctx.message.delete() # type: ignore
+        else:
+            await ctx.send(f'This command is only usable in {eventslounge.mention}', allowed_mentions=discord.AllowedMentions.none())
+
+    @commands.command()
+    async def eventspart(self, ctx: BBContext, members: commands.Greedy[discord.Member]):
+        participants_role = ctx.guild.get_role(events_participants)
+        log_channel = ctx.guild.get_channel(server_logs)
+
+        text = ''
+        for member in members:
+            await member.add_roles(participants_role)
+            text += f'\n{member.mention} ({member.id})'
+
+        embed = discord.Embed(title = 'Events Participants role added to:', description=text)
+        embed.set_author(name=ctx.author.name, icon_url=ctx.author.avatar.url)
+
+        await log_channel.send(embed=embed)
+        await ctx.tick()
+
+    @commands.command()
+    async def eventsunpart(self, ctx: BBContext, members: commands.Greedy[discord.Member]):
+        participants_role = ctx.guild.get_role(events_participants)
+        log_channel = ctx.guild.get_channel(server_logs)
+
+        text = ''
+        for member in members:
+            await member.remove_roles(participants_role)
+            text += f'\n{member.mention} ({member.id})'
+
+        embed = discord.Embed(title = 'Events Participants role removed from::', description=text)
+        embed.set_author(name=ctx.author.name, icon_url=ctx.author.avatar.url)
+
+        await log_channel.send(embed=embed)
+        await ctx.tick()
+
+    @commands.Cog.listener(name='on_reaction_add')
+    async def listener_wordsearch(self, reaction: discord.Reaction, user: discord.User):
+        if not self.listen_ws:
+            return
+        if not reaction.message.channel.id == events_answers:
+            return
+        if not str(reaction.emoji) in WORD_SEARCH_REACTIONS:
+            return
+
+        content = reaction.message.content.split()
+
+        # content[5] is the user mention for the user who used the ea command. The mentions property of Reaction.message is not used because we do not want this to fail if the user mentions someone inside ea command.
+        if not content[5].startswith(('<@!', '<@')):
+            return
+
+        eventslounge = self.bot.get_channel(events_lounge)
+        await eventslounge.send(WORD_SEARCH_REACTIONS[str(reaction.emoji)].format(content[5])) # type: ignore
+
+    @commands.Cog.listener(name='on_reaction_add')
+    async def listener_hangman(self, reaction: discord.Reaction, user: discord.User):
+        if not self.listen_hman:
+            return
+        if not reaction.message.channel.id == events_answers:
+            return
+        if not str(reaction.emoji) == f'<:check:461172408909430814>':
+            return
+
+        content = reaction.message.content.split()
+
+        # content[5] is the user mention for the user who used the ea command. The mentions property of Reaction.message is not used because we do not want this to fail if the user mentions someone inside ea command.
+        if content[5].startswith(('<@!')):
+            user_id = int(content[5][3:-1])
+        elif content[5].startswith('<@'):
+            user_id = int(content[5][2:-1])
+        else:
+            return
+
+        guild = reaction.message.guild
+        member = await self.bot.getch_member(guild, user_id) # type: ignore
+
+        if isinstance(member, int):
+            return
+        if member in self.hangman_players:
+            return
+        
+        eventslounge = self.bot.get_channel(events_lounge)
+        self.hangman_players.append(member)
+        eventsparts = guild.get_role(events_participants) # type: ignore
+
+        await member.add_roles(eventsparts) # type: ignore
+        await eventslounge.send(f'You are in {member.mention}.') # type: ignore
+
+        if len(self.hangman_players) >= 16:
+            masabot_commands = '\n'.join(f'm)any {self.hangman_players[i].mention} {self.hangman_players[i+1].mention} {eventslounge.mention} <word here>' for i in range(0, len(self.hangman_players), 2)) # type: ignore
+            await reaction.message.channel.send(f'{user.mention}, we have reached 16 members\n\n```{masabot_commands}```')
+            self.hangman_players = []
+
+    @commands.group(case_insensitive=True)
+    async def listen(self, ctx: BBContext):
+        pass
+
+    @listen.command(name='hangman')
+    async def listen_hangman(self, ctx: BBContext):
+        self.listen_hman = True
+        await ctx.send(f'Listening to <:check:461172408909430814>')
+    
+    @listen.command(name='wordsearch')
+    async def listen_wordsearch(self, ctx: BBContext):
+        self.listen_ws = True
+        reacts = ', '.join(WORD_SEARCH_REACTIONS.keys())
+        await ctx.send(f'Listening to {reacts}')
+
+    @commands.group(case_insensitive=True)
+    async def unlisten(self, ctx: BBContext):
+        pass
+
+    @unlisten.command(name='hangman')
+    async def unlisten_hangman(self, ctx: BBContext):
+        self.listen_hman = False
+        self.hangman_players = []
+        await ctx.send(f'Not listening to <:check:461172408909430814>')
+    
+    @unlisten.command(name='wordsearch')
+    async def unlisten_wordsearch(self, ctx: BBContext):
+        self.listen_ws = False
+        reacts = ', '.join(WORD_SEARCH_REACTIONS.keys())
+        await ctx.send(f'Not listening to {reacts}')
+
+    @commands.group()
+    async def events(self, ctx: BBContext):
+        pass
+
+    @events.group()
+    async def coins(self, ctx: BBContext):
+        pass
+
+    @coins.command()
+    async def add(self, ctx: BBContext, coins: int, member: discord.Member):
+        con = await ctx.get_connection()
+        player = await LeaderboardPlayer.fetch(con, member)
+
+        if player.level < 1:
+            return await ctx.send('Coins can not be added to anyone below level 1')
+            
+        await player.update(con, coins=coins)
+        await ctx.tick()
 
 def setup(bot: BunkerBot) -> None:
     bot.add_cog(events(bot))

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import re
 
 import asyncpg
 import discord
@@ -10,11 +9,16 @@ from context import BBContext
 from utils.constants import MR_K, SIGNAL, TICKET
 from discord.ext import commands
 from random import randint, choices
-from typing import List, Tuple, Dict
+from typing import List, Optional, Tuple, Dict
 from utils.levels import LeaderboardPlayer
 
 
 TABLE_CURRENCY = 'events.currency'
+AWARDS = { # difficulty_level: (min reward, max reward)
+    75: (10, 20), # easy
+    45: (30, 50), # medium
+    25: (80, 100) # hard
+}
 
 
 class Situation:
@@ -57,9 +61,7 @@ class GameButton(discord.ui.Button):
         )
     
     async def callback(self, interaction: discord.Interaction):
-        outcome = self.view.determine_situation_successs
-        diff = self.view.difficulty
-        profit = randint(4*diff, 8*diff) if outcome else -randint(2*diff, 5*diff)
+        outcome, profit = self.view.determine_situation_successs
         self.view.player_score += profit
         self.view.clear_items()
 
@@ -68,11 +70,35 @@ class GameButton(discord.ui.Button):
             if outcome_bool == outcome:
                 break
 
-        if self.view.situations:
-            self.view.add_item(SegwayButton(self.view.situations.pop()))
-            embed = discord.Embed(description=f'{outcome_response}. You earned {profit} {TICKET}' if profit > 0 else f'You lost {-profit} {TICKET}').set_image(url=SIGNAL)
-            await interaction.response.edit_message(embed=embed, view=self.view)
+
+        self.view.add_item(SegwayButton())
+        embed = discord.Embed(description=f'Total: {self.view.player_score} {TICKET}\n{outcome_response}. You earned {profit} {TICKET}' if profit > 0 else f'You lost {-profit} {TICKET}').set_image(url=SIGNAL)
+        await interaction.response.edit_message(embed=embed, view=self.view)
         
+
+class SegwayButton(discord.ui.Button):
+    """
+    A discord button that is sent between game situations
+    """
+
+    view: GameView
+    def __init__(self):
+        super().__init__(
+            style=discord.ButtonStyle.gray, 
+            label='Next'
+        )
+    
+    async def callback(self, interaction: discord.Interaction):
+        self.view.clear_items()
+        if self.view.situations:
+            next_situation = self.view.situations.pop()
+
+            for option in next_situation.options:
+                self.view.add_item(GameButton(option))
+        
+            embed = discord.Embed(description=f'Total: {self.view.player_score} {TICKET}\n{next_situation.desciption}').set_image(url=SIGNAL)
+            await interaction.response.edit_message(embed=embed, view=self.view)
+
         else:
             if self.view.player_score > 0:
                 self.view.add_item(PayoutButton(f'{self.view.player_score} (Collect)'))
@@ -81,41 +107,17 @@ class GameButton(discord.ui.Button):
                 embed= discord.Embed(description='You are lucky I am not making you pay for my losses.').set_image(url=MR_K)
                 await interaction.response.edit_message(embed=embed, view=None)
                 self.view.stop()
-        
-
-class SegwayButton(discord.ui.Button):
-    """
-    A discord button that is sent between game situations
-
-    Parameters
-    -----------
-    next_situation: Situation
-        The next situation the survivor has to face during the event
-    """
-
-    view: GameView
-    def __init__(self, next_situation: Situation):
-        self.next_situation = next_situation
-
-        super().__init__(
-            style=discord.ButtonStyle.gray, 
-            label='Next'
-        )
-    
-    async def callback(self, interaction: discord.Interaction):
-        self.view.clear_items()
-
-        for option in self.next_situation.options:
-            self.view.add_item(GameButton(option))
-        
-        embed = discord.Embed(description=self.next_situation.desciption).set_image(url=SIGNAL)
-        await interaction.response.edit_message(embed=embed, view=self.view)
 
 
 class PayoutButton(discord.ui.Button):
     """
     A discord button that is sent at the end of the game when all situations are delt with. This is only sent if the survivor
     profited
+
+    Parameters
+    -----------
+    label: str
+        The text that appears on this button
     """
 
     view: GameView
@@ -135,6 +137,110 @@ class PayoutButton(discord.ui.Button):
         
         await interaction.response.edit_message(embed=embed, view=None)
         self.view.stop()
+
+
+class DifficultySelect(discord.ui.Select):
+    """
+    A discord select menu that is sent at the start of the game. This allows the survivor to select the difficulty level of the game.
+    Higher the difficulty, better the prizes. The select is disabled if the player is not at least level 5
+
+    Parameters
+    -----------
+    placeholder: str
+        The text that appears on the select when no option is selected
+    disabled: bool
+        bool representing if the select is disabled or not
+    """
+
+    view: GameView
+    def __init__(self, *, placeholder: Optional[str], disabled: bool) -> None:
+        super().__init__(
+            placeholder=placeholder, 
+            disabled=disabled, 
+            options=[
+                discord.SelectOption(label='Easy', value='75'),
+                discord.SelectOption(label='Medium', value='45'),
+                discord.SelectOption(label='Hard', value='25')
+            ]
+            )
+    
+    async def callback(self, interaction: discord.Interaction) -> None:
+        self.disabled = True
+        self.view.difficulty = int(self.values[0])
+        await interaction.response.edit_message(view=self.view)
+
+
+class BoostSelect(discord.ui.Select):
+    """
+    A discord select menu that is sent at the start of the game. This allows the survivor to select a boost that is applied to the game.
+    The select is disabled if the player is not at least level 10
+
+    Parameters
+    -----------
+    placeholder: str
+        The text that appears on the select when no option is selected
+    disabled: bool
+        bool representing if the select is disabled or not
+    """
+
+    view: GameView
+    def __init__(self, *, placeholder: Optional[str], disabled: bool) -> None:
+        super().__init__(
+            placeholder=placeholder, 
+            disabled=disabled,
+            options=[
+                discord.SelectOption(label='No losses', description='Even if you lose a situation you will not recieve negative points.', value='1'),
+                discord.SelectOption(label='2x Rewards', description='Get double the rewards!.', value='2'),
+                discord.SelectOption(label='One extra situation', description='Instead of 3 situations you face 4!', value='3')
+            ]
+            )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        val = int(self.values[0])
+        self.disabled = True
+        if val == 1:
+            self.view.no_losses = True
+        elif val == 2:
+            self.view.double_rewards = True
+        elif val == 3:
+            self.view.no_of_situations += 1
+        await interaction.response.edit_message(view=self.view)
+
+
+class ChooseGameSelect(discord.ui.Select):
+    """
+    A discord select menu that is sent at the start of the game. This allows the survivor to select an event for the game.
+
+    Parameters
+    -----------
+    options: List[discord.SelectOption]
+        List of Select Options each representing an event
+    """
+    view: GameView
+    def __init__(self, *, options: List[discord.SelectOption]) -> None:
+        super().__init__(
+            placeholder='Select Task',
+            options=options, 
+            )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        event_id = int(self.values[0])
+        query = 'SELECT description, outcomes FROM events.situations WHERE game_id = $1 ORDER BY random() LIMIT $2'
+        self.view.clear_items()
+
+        async with self.view.bot.pool.acquire() as con:
+            rows: List[asyncpg.Record] = await con.fetch(query, event_id, self.view.no_of_situations)
+            self.view.situations = [Situation(description, json.loads(options)) for (description, options) in rows]
+
+        next_situation = self.view.situations.pop()
+        for option in next_situation.options:
+            self.view.add_item(GameButton(option))
+        
+        embed = discord.Embed(description=next_situation.desciption).set_image(url=SIGNAL)
+        await interaction.response.edit_message(embed=embed, view=self.view)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return self.player.user.id == interaction.user.id # type: ignore
 
 
 class GameView(discord.ui.View):
@@ -161,47 +267,40 @@ class GameView(discord.ui.View):
     def __init__(self, player: LeaderboardPlayer, game_names: List[Tuple[str, int]]):
         super().__init__()
         self.player = player
+        self.no_of_situations: int = 3
         self.player_score: int = 0
-        self.difficulty: int = 2
+        self.difficulty: int = 75
+        self.double_rewards: bool = False
+        self.no_losses: bool = False
 
-        self.choose_difficulty.options = [
-            discord.SelectOption(label='Easy', value='2', default=True),
-            discord.SelectOption(label='Medium', value='3'),
-            discord.SelectOption(label='Hard', value='4')
-        ]
+        if player.level < 5:
+            self.add_item(DifficultySelect(placeholder='Reach lvl 5 to unlock difficulties', disabled=True))
+        else:
+            self.add_item(DifficultySelect(placeholder='Select Difficulty', disabled=False))
 
-        self.choose_event.options = [discord.SelectOption(label=game_name, value=str(game_id)) for (game_name, game_id) in game_names]
+        if player.level < 10:
+            self.add_item(BoostSelect(placeholder='Reach lvl 10 to unlock boosts', disabled=True))
+        else:
+            self.add_item(BoostSelect(placeholder='Select Boost', disabled=False))
+
+        self.add_item(ChooseGameSelect(options=[discord.SelectOption(label=game_name, value=str(game_id)) for (game_name, game_id) in game_names]))
 
     @property
-    def determine_situation_successs(self) -> bool:
-        return True if randint(1, 100) % self.difficulty == 0 else False
+    def determine_situation_successs(self) -> Tuple[bool, int]:
+        outcome = True if randint(1, 100) <= self.difficulty else False
+        min_rewards, max_reward = AWARDS[self.difficulty]
+        prize = randint(min_rewards, max_reward) if outcome else -randint(min_rewards/2, max_reward/2)
 
-    @discord.ui.select(placeholder='Select Difficulty')
-    async def choose_difficulty(self, select: discord.ui.Select, interaction: discord.Interaction) -> None:
-        select.disabled = True
-        self.difficulty = int(select.values[0])
-        await interaction.response.edit_message(view=self)
+        if self.no_losses and prize < 0:
+            prize = 0
 
-    @discord.ui.select(placeholder='Select Task')
-    async def choose_event(self, select: discord.ui.Select, interaction: discord.Interaction) -> None:
-        event_id = int(select.values[0])
-        query = 'SELECT description, outcomes FROM events.situations WHERE game_id = $1 ORDER BY random() LIMIT 3'
-        self.clear_items()
+        if self.double_rewards and prize > 0:
+            prize *= 2
 
-        async with self.bot.pool.acquire() as con:
-            rows: List[asyncpg.Record] = await con.fetch(query, event_id)
-            self.situations = [Situation(description, json.loads(options)) for (description, options) in rows]
-
-        next_situation = self.situations.pop()
-        for option in next_situation.options:
-            self.add_item(GameButton(option))
-        
-        embed = discord.Embed(description=next_situation.desciption).set_image(url=SIGNAL)
-        await interaction.response.edit_message(embed=embed, view=self)
+        return outcome, prize
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         return self.player.user.id == interaction.user.id # type: ignore
-
 
 
 class game(commands.Cog):
@@ -219,8 +318,8 @@ class game(commands.Cog):
             self.games = [(game_name, game_id) for (game_id, game_name) in rows]
     
 
-    @commands.command() # TODO name?
-    async def test(self, ctx: BBContext):
+    @commands.command(aliases=['tasks']) # TODO name?
+    async def task(self, ctx: BBContext):
         player = await LeaderboardPlayer.fetch(await ctx.get_connection(), ctx.author)
 
         if player.level < 1:

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -236,11 +236,8 @@ class ChooseGameSelect(discord.ui.Select):
         for option in next_situation.options:
             self.view.add_item(GameButton(option))
         
-        embed = discord.Embed(description=next_situation.desciption).set_image(url=SIGNAL)
+        embed = discord.Embed(description=f'Total: {self.view.player_score} {TICKET}\n{next_situation.desciption}').set_image(url=SIGNAL)
         await interaction.response.edit_message(embed=embed, view=self.view)
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        return self.player.user.id == interaction.user.id # type: ignore
 
 
 class GameView(discord.ui.View):

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+import asyncpg
+import discord
+
+from bot import BunkerBot
+from context import BBContext
+from discord.ext import commands, tasks
+from typing import Callable, Dict, List, Union
+from utils.constants import TABLE_LB_CONFIG, TABLE_LEADERBOARD, TICKET, NO_XP_CHANNELS
+from utils.levels import LeaderboardPlayer
+from utils.views import EmbedViewPagination
+
+
+DEFAULT_XP = 0.01
+
+
+class LevelConfigPages(EmbedViewPagination):
+    def __init__(self, user_id: int, data: List[asyncpg.Record]):
+        super().__init__(data, per_page=10)
+        self.user_id = user_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return self.user_id == interaction.user.id # type: ignore
+
+    async def format_page(self, data: List[asyncpg.Record]) -> discord.Embed:
+        description = '\n'.join(f'Level: **{row["level"]}**\nXP: **{row["required_xp"]}**, Prize: **{row["prize"]}**' for row in data)
+        return discord.Embed(title='Levels', description=description)
+
+
+class LeaderboardPages(EmbedViewPagination):
+    def __init__(self, user_id: int, data: List[asyncpg.Record], *, bot: BunkerBot):
+        super().__init__(data, per_page=10)
+        self.user_id = user_id
+        self.get_user: Callable[[int], Union[discord.User, int]] = lambda user_id: bot.get_user(user_id) or user_id
+
+    async def format_page(self, data: List[asyncpg.Record]) -> discord.Embed:
+        start = (self.current_page-1) * self.per_page
+        description = '\n'.join(f'{start+i+1}) {self.get_user(user_id)}: {xp}' for i, (user_id, xp) in enumerate(data))
+        return discord.Embed(title='Leaderboard', description=description).set_footer(text=f'Page {self.current_page}/{self.max_pages}')
+
+
+class leaderboard(commands.Cog):
+    def __init__(self, bot: BunkerBot) -> None:
+        self.bot = bot
+        self.xp_channel_mapping : Dict[int, int] = {}
+
+        self.xp_task.start()
+
+    def cog_unload(self):
+        self.xp_task.cancel()
+
+    @commands.Cog.listener(name='on_message')
+    async def add_message(self, message: discord.Message) -> None:
+        """
+        Increments the xp for a player in the xp cache
+
+        Parameters
+        -----------
+        message: discord.Message
+            message received by the listener
+        """
+        if message.author.bot or message.channel.id in NO_XP_CHANNELS:
+            return
+
+        try:
+            self.bot.xp_cache[message.author.id] += self.xp_channel_mapping.get(message.channel.id, DEFAULT_XP)
+        except KeyError:
+            self.bot.xp_cache[message.author.id] = self.xp_channel_mapping.get(message.channel.id, DEFAULT_XP)
+
+    # @tasks.loop(minutes=10) TODO remove
+    @tasks.loop(seconds=10)
+    async def xp_task(self) -> None:
+        """
+        Task that updates the xp from memory to db every 10 minutes
+        """
+        await self.bot.update_xp()
+
+    @commands.group(invoke_without_command=True, aliases=['xp'])
+    async def level(self, ctx: BBContext):
+        con = await ctx.get_connection()
+        player = await LeaderboardPlayer.fetch(con, ctx.author)
+        embed = discord.Embed(
+            title=f'{ctx.author.name}#{ctx.author.discriminator}', 
+            description=f'Level: **{player.level}**\n\
+                          XP: **{player.xp}**\n\
+                          Coins: **{player.coins}**\n\
+                          Tickets: **{player.tickets}** {TICKET}'
+            )
+            # TODO add event coin emoji
+
+        await ctx.send(embed=embed)
+
+    @level.group(invoke_without_subcommand=True)
+    @commands.has_guild_permissions(administrator=True)
+    async def config(self, ctx: BBContext):
+        con = await ctx.get_connection()
+        query = f'SELECT level, required_xp, prize FROM {TABLE_LB_CONFIG}'
+
+        rows = await con.fetch(query)
+        view = LevelConfigPages(ctx.author.id, rows)
+        await view.start(ctx.channel)
+
+    @commands.command(name='leaderboard', aliases=['lb'])
+    async def show_leaderboard(self, ctx: BBContext):
+        con = await ctx.get_connection()
+        query = f'SELECT user_id, xp FROM {TABLE_LEADERBOARD} ORDER BY xp DESC LIMIT 100'
+        rows = await con.fetch(query)
+        view = LeaderboardPages(ctx.author.id, rows, bot=self.bot)
+        await view.start(ctx.channel)
+
+
+def setup(bot: BunkerBot) -> None:
+    bot.add_cog(leaderboard(bot))

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -6,7 +6,7 @@ from bot import BunkerBot
 from context import BBContext
 from discord.ext import commands, tasks
 from typing import Callable, Dict, List, Union
-from utils.constants import TABLE_LB_CONFIG, TABLE_LEADERBOARD, TICKET, NO_XP_CHANNELS
+from utils.constants import TABLE_LB_CONFIG, TABLE_LEADERBOARD, TICKET, NO_XP_CHANNELS, COINS
 from utils.levels import LeaderboardPlayer
 from utils.views import EmbedViewPagination
 
@@ -67,8 +67,7 @@ class leaderboard(commands.Cog):
         except KeyError:
             self.bot.xp_cache[message.author.id] = self.xp_channel_mapping.get(message.channel.id, DEFAULT_XP)
 
-    # @tasks.loop(minutes=10) TODO remove
-    @tasks.loop(seconds=10)
+    @tasks.loop(minutes=10)
     async def xp_task(self) -> None:
         """
         Task that updates the xp from memory to db every 10 minutes
@@ -81,12 +80,7 @@ class leaderboard(commands.Cog):
         player = await LeaderboardPlayer.fetch(con, ctx.author)
         embed = discord.Embed(
             title=f'{ctx.author.name}#{ctx.author.discriminator}', 
-            description=f'Level: **{player.level}**\n\
-                          XP: **{player.xp}**\n\
-                          Coins: **{player.coins}**\n\
-                          Tickets: **{player.tickets}** {TICKET}'
-            )
-            # TODO add event coin emoji
+            description=f'Level: **{player.level}**\nXP: **{player.xp}**\nCoins: **{player.coins}**  {COINS}\nTickets: **{player.tickets}** {TICKET}')
 
         await ctx.send(embed=embed)
 

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -1,0 +1,14 @@
+import discord
+
+from bot import BunkerBot
+from context import BBContext
+from discord.ext import commands
+
+
+class shop(commands.Cog):
+    def __init__(self, bot: BunkerBot) -> None:
+        self.bot = bot
+
+
+def setup(bot: BunkerBot) -> None:
+    bot.add_cog(shop(bot))

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -6,10 +6,11 @@ from bot import BunkerBot
 from context import BBContext
 from datetime import timedelta
 from discord.ext import commands
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 from utils.constants import COINS, TICKET
+from utils.converters import TimeConverter
 from utils.levels import LeaderboardPlayer
-from utils.views import EmbedViewPagination
+from utils.views import Confirm, EmbedViewPagination
 
 
 TABLE_CURRENCY = 'events.currency'
@@ -24,7 +25,7 @@ CURRENCY_EMOJI = {
 class ShopItem:
     __slots__ = ('id', 'name', 'price', 'currency', 'stock', 'minimum_level', 'description', 'cooldown', 'emoji', 'amount',)
 
-    def __init__(self, *, id: int, name: str, price: int, currency: str, stock: int, minimum_level: int, description: str, cooldown: int, emoji: str, amount: int) -> None:
+    def __init__(self, *, id: int, name: str, price: int, currency: str, stock: Optional[int], minimum_level: int, description: Optional[str], cooldown: Optional[int], emoji: Optional[str], amount: int) -> None:
         self.id = id
         self.name = name
         self.price = price
@@ -67,17 +68,22 @@ class ShopSelect(discord.ui.Select):
             raise ValueError(f'Invalid currency: {item.currency} for item: {item.name} with ID: {item.id}')
 
 
-        last_bought_item = discord.utils.utcnow() + timedelta(seconds=item.cooldown)
         async with self.view.bot.pool.acquire() as con:
             con: asyncpg.Connection
 
             async with con.transaction():
-                query = f'SELECT EXISTS (SELECT FROM {TABLE_SHOP_LOG} WHERE user_id = $1 and item_id = $2 and time < $3)'
-                if await con.fetchval(query, self.view.player.user.id, item.id, last_bought_item):
-                    return await interaction.response.send_message(f'You can not buy this item again so soon.')
+
+                if item.cooldown:
+                    last_bought_item = discord.utils.utcnow() + timedelta(seconds=item.cooldown)
+                    query = f'SELECT EXISTS (SELECT FROM {TABLE_SHOP_LOG} WHERE user_id = $1 and item_id = $2 and time < $3)'
+                    if await con.fetchval(query, self.view.player.user.id, item.id, last_bought_item):
+                        return await interaction.response.send_message(f'You can not buy this item again so soon.')
 
                 query = f'INSERT INTO {TABLE_SHOP_LOG}(user_id, item_id, price, time, item_name, item_amount, currency_used) VALUES($1, $2, $3, $4, $5, $6, $7)'
-                await con.execute(query, self.view.player.user.id, item.id, item.price, discord.utils.utcnow(), item.name, item.amount, item.currency) # tickets are subtracted and coins are added to players balance via a trigger in case the item is Event Coins
+                await con.execute(query, self.view.player.user.id, item.id, item.price, discord.utils.utcnow(), item.name, item.amount, item.currency) 
+                # tickets and coins are subtracted automatically and stock is updated via triggers
+                # Event Coins are also transffered via the same if bought
+
                 await interaction.response.send_message(f'You just bought **{item.amount} {item.name}**! If this is an in-game item a staff member will contact you soon!')
 
 
@@ -87,7 +93,7 @@ class Shop(EmbedViewPagination):
         self.bot = bot
         self.player = player
         
-        options = [discord.SelectOption(label=item.name, value=str(item.id), emoji=item.emoji, description=f'Cost: {item.price} {item.currency}') for item in items]
+        options = [discord.SelectOption(label=f'{item.amount} {item.name}', value=str(item.id), emoji=item.emoji, description=f'Cost: {item.price} {item.currency}') for item in items]
         self.add_item(ShopSelect(options=options[:24])) # currently only supporting one select i.e. 25 items in shop
         self.shop_items: Dict[int, ShopItem] = dict([(item.id, item) for item in items])
             
@@ -126,6 +132,44 @@ class Shop(EmbedViewPagination):
         return self.message
 
 
+class ShopListPages(EmbedViewPagination):
+    def __init__(self, user_id: int, data: List[asyncpg.Record]):
+        super().__init__(data, per_page=10)
+        self.user_id = user_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user.id == self.user_id # type: ignore
+
+    async def format_page(self, data: List[asyncpg.Record]) -> discord.Embed:
+        description = '\n'.join(f'ID: {item[0]}\nName: {item[1]}\n Amount: {item[2]}\n' for item in data)
+        embed = discord.Embed(title='Shop Items', description=description)
+        embed.set_footer(text=f'{self.current_page}/{self.max_pages}')
+        return embed
+
+
+class ShopItemCreateFlags(commands.FlagConverter, delimiter=' ', prefix='-'):
+    name: str = commands.flag(aliases=['n'])
+    description: Optional[str] = commands.flag(aliases=['d'])
+    emoji: Optional[discord.Emoji] = commands.flag(aliases=['e'])
+    price: int = commands.flag(aliases=['p'])
+    stock: Optional[int] = commands.flag(aliases=['s'])
+    minimum_level: int = commands.flag(aliases=['ml'])
+    cooldown: Optional[TimeConverter] = commands.flag(aliases=['c'])
+    amount: int = commands.flag(aliases=['a'])
+
+
+class ShopItemUpdateFlags(commands.FlagConverter, delimiter=' ', prefix='-'):
+    id: int
+    name: Optional[str] = commands.flag(aliases=['n'])
+    description: Optional[str] = commands.flag(aliases=['d'])
+    emoji: Optional[discord.Emoji] = commands.flag(aliases=['e'])
+    price: Optional[int] = commands.flag(aliases=['p'])
+    stock: Optional[int] = commands.flag(aliases=['s'])
+    minimum_level: Optional[int] = commands.flag(aliases=['ml'])
+    cooldown: Optional[TimeConverter] = commands.flag(aliases=['c'])
+    amount: Optional[int] = commands.flag(aliases=['a'])
+
+
 class shop(commands.Cog):
     def __init__(self, bot: BunkerBot) -> None:
         self.bot = bot
@@ -135,20 +179,90 @@ class shop(commands.Cog):
         shop = await Shop.fetch_with_items(ctx.author, self.bot)
         await shop.start(ctx.channel)
 
-    @shop.group()
+    @shop.command()
     @commands.has_guild_permissions(administrator=True)
-    async def create(self, ctx: BBContext):
-        ...
+    async def list(self, ctx: BBContext):
+        con = await ctx.get_connection()
+        query = f'SELECT id, name, amount FROM {TABLE_SHOP}'
+        rows = await con.fetch(query)
+        view = ShopListPages(ctx.author.id, rows)
+        await view.start(ctx.channel)
 
     @shop.group()
     @commands.has_guild_permissions(administrator=True)
-    async def delete(self, ctx: BBContext):
-        ...
+    async def add(self, ctx: BBContext, *, flags: ShopItemCreateFlags):
+        con = await ctx.get_connection()
+        query = f'INSERT INTO {TABLE_SHOP}(name, description, emoji, price, currency, stock, minimum_level, cooldown, amount) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)'
+        await con.execute(query, flags.name, flags.description, flags.emoji, flags.price, 'event coins', flags.stock, flags.minimum_level, flags.cooldown, flags.amount)
+        await ctx.tick()
 
     @shop.group()
     @commands.has_guild_permissions(administrator=True)
-    async def update(self, ctx: BBContext):
-        ...
+    async def delete(self, ctx: BBContext, item_id: int):
+        confirm = Confirm(ctx.author.id)
+        await ctx.send(f'Are you sure you want to delete shop item with ID: {item_id}', view=confirm)
+
+        await confirm.wait()
+        if confirm.result:
+            con = await ctx.get_connection()
+            query = f'DELETE FROM {TABLE_SHOP} WHERE id = $1'
+            await con.execute(query, item_id)
+
+    @shop.group()
+    @commands.has_guild_permissions(administrator=True)
+    async def update(self, ctx: BBContext, *, flags: ShopItemUpdateFlags):
+        columns = []
+        args = []
+        
+        if flags.name:
+            columns.append('name')
+            args.append(flags.name)
+
+        if flags.description:
+            columns.append('description')
+            args.append(flags.description)
+
+        if flags.emoji:
+            columns.append('emoji')
+            args.append(flags.emoji)
+
+        if flags.price:
+            columns.append('price')
+            args.append(flags.price)
+
+        if flags.stock == -1:
+            columns.append('stock')
+            args.append(None)
+        elif flags.stock:
+            columns.append('stock')
+            args.append(flags.stock)
+
+        if flags.minimum_level:
+            columns.append('minimum_level')
+            args.append(flags.minimum_level)
+
+        if flags.cooldown:
+            columns.append('cooldown')
+            args.append(flags.cooldown)
+
+        if flags.amount:
+            columns.append('amount')
+            args.append(flags.amount)
+
+        if not args:
+            return await ctx.send('You must provide at least one field to update')
+
+        con = await ctx.get_connection()
+        cols = ', '.join(f'{col}=${i+2}' for i, col in enumerate(columns))
+        query = f'UPDATE {TABLE_SHOP} SET {cols} WHERE id = $1'
+        args.insert(0, flags.id)
+        args.insert(0, query)
+        
+        val = await con.execute(*args)
+        if val == 'UPDATE 0':
+             await ctx.send(f'No shop item found with ID: **{flags.id}**')
+        else:
+            await ctx.tick()
 
 
 def setup(bot: BunkerBot) -> None:

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -1,13 +1,154 @@
+from __future__ import annotations
+import asyncpg
 import discord
 
 from bot import BunkerBot
 from context import BBContext
+from datetime import timedelta
 from discord.ext import commands
+from typing import Dict, List, Union
+from utils.constants import COINS, TICKET
+from utils.levels import LeaderboardPlayer
+from utils.views import EmbedViewPagination
+
+
+TABLE_CURRENCY = 'events.currency'
+TABLE_SHOP = 'events.shop'
+TABLE_SHOP_LOG = 'events.shop_log'
+CURRENCY_EMOJI = {
+    'tickets': TICKET,
+    'event coins': COINS
+}
+
+
+class ShopItem:
+    __slots__ = ('id', 'name', 'price', 'currency', 'stock', 'minimum_level', 'description', 'cooldown', 'emoji', 'amount',)
+
+    def __init__(self, *, id: int, name: str, price: int, currency: str, stock: int, minimum_level: int, description: str, cooldown: int, emoji: str, amount: int) -> None:
+        self.id = id
+        self.name = name
+        self.price = price
+        self.currency = currency
+        self.stock = stock
+        self.minimum_level = minimum_level
+        self.description = description
+        self.cooldown = cooldown
+        self.emoji = emoji
+        self.amount = amount
+
+
+class ShopSelect(discord.ui.Select):
+    view: Shop
+    def __init__(self, *, options: List[discord.SelectOption]) -> None:
+        super().__init__(
+            placeholder='Select an Item to buy', 
+            options=options
+            )
+    
+    async def callback(self, interaction: discord.Interaction):
+        item_id = int(self.values[0])
+        item: ShopItem = self.view.shop_items[item_id]
+
+        if item.minimum_level > self.view.player.level:
+            return await interaction.response.send_message(f'You must be at least level **{item.minimum_level}** to buy this item, however you are only level **{self.view.player.level}**.')
+
+        if item.stock:
+            if item.stock <= 0:
+                return await interaction.response.send_message('This item is out of stock. You can not buy it right now', ephemeral=True)
+
+
+        if item.currency == 'tickets':
+            if item.price > self.view.player.tickets:
+                return await interaction.response.send_message(f'You do not have enough tickets to buy **{item.name}**', ephemeral=True)
+        elif item.currency == 'event coins':
+            if item.price > self.view.player.coins:
+                return await interaction.response.send_message(f'You do not have enough event coins to buy **{item.name}**', ephemeral=True)
+        else:
+            raise ValueError(f'Invalid currency: {item.currency} for item: {item.name} with ID: {item.id}')
+
+
+        last_bought_item = discord.utils.utcnow() + timedelta(seconds=item.cooldown)
+        async with self.view.bot.pool.acquire() as con:
+            con: asyncpg.Connection
+
+            async with con.transaction():
+                query = f'SELECT EXISTS (SELECT FROM {TABLE_SHOP_LOG} WHERE user_id = $1 and item_id = $2 and time < $3)'
+                if await con.fetchval(query, self.view.player.user.id, item.id, last_bought_item):
+                    return await interaction.response.send_message(f'You can not buy this item again so soon.')
+
+                query = f'INSERT INTO {TABLE_SHOP_LOG}(user_id, item_id, price, time, item_name, item_amount, currency_used) VALUES($1, $2, $3, $4, $5, $6, $7)'
+                await con.execute(query, self.view.player.user.id, item.id, item.price, discord.utils.utcnow(), item.name, item.amount, item.currency) # tickets are subtracted and coins are added to players balance via a trigger in case the item is Event Coins
+                await interaction.response.send_message(f'You just bought **{item.amount} {item.name}**! If this is an in-game item a staff member will contact you soon!')
+
+
+class Shop(EmbedViewPagination):
+    def __init__(self, player: LeaderboardPlayer, bot: BunkerBot, items: List[ShopItem]) -> None:
+        super().__init__(items, per_page=5)
+        self.bot = bot
+        self.player = player
+        
+        options = [discord.SelectOption(label=item.name, value=str(item.id), emoji=item.emoji, description=f'Cost: {item.price} {item.currency}') for item in items]
+        self.add_item(ShopSelect(options=options[:24])) # currently only supporting one select i.e. 25 items in shop
+        self.shop_items: Dict[int, ShopItem] = dict([(item.id, item) for item in items])
+            
+    @classmethod
+    async def fetch_with_items(cls, user: Union[discord.Member, discord.User], bot: BunkerBot) -> Shop:
+        async with bot.pool.acquire() as con:
+            player = await LeaderboardPlayer.fetch(con, user)
+            query = f'SELECT id, name, description, emoji, price, currency, stock, minimum_level, cooldown, amount FROM {TABLE_SHOP} ORDER BY price'
+
+            rows = await con.fetch(query)
+            items = [ShopItem(**dict(row)) for row in rows]
+
+        return cls(player, bot, items)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.player.user.id: # type: ignore
+            await interaction.response.send_message('You can not interact with this shop. Get your own shop using `b!shop` command.', ephemeral=True)
+            return False
+        else:
+            return True
+
+    async def format_page(self, data: List[ShopItem]) -> discord.Embed:
+        embed = discord.Embed(title='Shop').set_footer(text=f'{self.current_page}/{self.max_pages}')
+        for item in data:
+            embed.add_field(name=f'{item.amount} {item.name} ({item.price} {CURRENCY_EMOJI[item.currency]})', value=f'**Description:** {item.description}\n**Level required**: {item.minimum_level}\n**Stock:** {item.stock or "∞"}')
+        return embed
+
+    async def start(self, channel: discord.abc.Messageable) -> discord.Message:
+        if self.max_pages == 1:
+            self.first_page.disabled = True
+            self.previous_page.disabled = True
+            self.next_page.disabled = True
+            self.last_page.disabled = True
+
+        self.message = await channel.send(embed=await self.format_page(self._data[0]), view=self)
+        return self.message
 
 
 class shop(commands.Cog):
     def __init__(self, bot: BunkerBot) -> None:
         self.bot = bot
+
+    @commands.group(invoke_without_command=True)
+    async def shop(self, ctx: BBContext):
+        shop = await Shop.fetch_with_items(ctx.author, self.bot)
+        await shop.start(ctx.channel)
+
+    @shop.group()
+    @commands.has_guild_permissions(administrator=True)
+    async def create(self, ctx: BBContext):
+        ...
+
+    @shop.group()
+    @commands.has_guild_permissions(administrator=True)
+    async def delete(self, ctx: BBContext):
+        ...
+
+    @shop.group()
+    @commands.has_guild_permissions(administrator=True)
+    async def update(self, ctx: BBContext):
+        ...
 
 
 def setup(bot: BunkerBot) -> None:

--- a/utils/converters.py
+++ b/utils/converters.py
@@ -1,0 +1,26 @@
+import re
+
+from context import BBContext
+from discord.ext import commands
+
+time_regex = re.compile(r'(\d{1,5}(?:[.,]?\d{1,5})?)([smhdw])', re.IGNORECASE)
+time_dict = {
+    's': 1, 
+    'm': 60, 
+    'h': 3600, 
+    'd': 86400,
+    'w': 604800
+    }
+
+class TimeConverter(commands.Converter):
+    async def convert(self, ctx: BBContext, argument: str) -> float:
+        matches = time_regex.findall(argument)
+        time = 0
+        for v, k in matches:
+            try:
+                time += time_dict[k]*float(v)
+            except KeyError:
+                raise commands.BadArgument(f'{k} is an invalid time specifer! s/m/h/d/w are valid and stand for seconds, minutes, hours, days and weeks respectively.')
+            except ValueError:
+                raise commands.BadArgument(f'{v} is not a number!')
+        return time

--- a/utils/levels.py
+++ b/utils/levels.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+from typing import Union
+import asyncpg
+import discord
+
+
+class LeaderboardPlayer:
+    """
+    Represents a player in leaderboard
+
+    Parameters
+    -----------
+    user: Union[discord.Member, discord.User]
+        Member or User object
+    xp: float
+        Player's current xp. This is xp stored in database + the one in memory
+    tickets: int
+        Amount of tickets the player has
+    coins: int
+        Amount of tickets the player has.
+    level: int
+        PLayer's current level
+    """
+
+    __slots__ = ('user', 'xp', 'tickets', 'coins', 'level')
+
+    def __init__(self, user: Union[discord.Member, discord.User], *, xp: float = 0.0, tickets: int = 0, coins: int = 0, level: int = 0) -> None:
+        self.user = user
+        self.xp = xp
+        self.tickets = tickets
+        self.coins = coins
+        self.level = level
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, LeaderboardPlayer):
+            return self.user.id == other.user.id
+        elif isinstance(other, int):
+            return self.user.id == other
+        return False
+
+    def __repr__(self) -> str:
+        return f'LeaderboardPlayer<id={self.user.id} xp={self.xp} coins={self.coins} tickets={self.tickets} level={self.level}>'
+
+    @classmethod
+    async def fetch(cls, con: asyncpg.Connection, user: Union[discord.Member, discord.User]):
+        query = 'SELECT l.xp, c.level, c.tickets, c.coins \
+                 FROM events.leaderboard l \
+                 INNER JOIN events.currency c ON l.user_id = c.user_id \
+                 WHERE l.user_id = $1'
+
+        row = await con.fetchrow(query, user.id)
+        if row:
+            return cls(
+                user,
+                xp = row['xp'] or 0.0,
+                tickets = row['tickets'] or 0,
+                coins = row['coins'] or 0,
+                level = row['level'] or 0 
+            )
+        
+        return cls(user)
+
+    async def update(self, con: asyncpg.Connection, *, tickets: int = 0, coins: int = 0) -> str:
+        if tickets == coins == 0:
+            raise ValueError('You need to provide at least one: tickets or coins')
+
+        query = 'INSERT INTO events.currency(user_id, tickets, coins) \
+                 VALUES($1, $2, $3) \
+                 ON CONFLICT(user_id) DO UPDATE \
+                 SET tickets = coalesce(events.currency.tickets, 0) + $2, \
+                 coins = coalesce(events.currency.coins, 0) + $3'
+        return await con.execute(query, self.user.id, tickets, coins)


### PR DESCRIPTION
Adding support for games and events.

**Games**
- [x] Change requirement to play game be at least level 1
- [x] Change ability to change difficulty to level 5
- [x] Add boost ability for level 10

**Levels**
- [x] Add xp on message
- [x] View your xp, level, tickets and coins
- [x] View leader board
- [x] XP cooldown
- [x] Cooldown on lb and xp commands

**Events**
- [x] Ea command
- [x] Hangman Listener
- [x] Hangman masabot support, auto generate commands
- [x] Word Search Listener
- [x] Ability to distribute coins

~~Events Scheduler (maybe)~~ (This depended on Team Up API which is not working as expected. So this will not be included in this version)

**Shop**
- [x] View and buy from shop
- [x] Add items from shop
- [x] Delete items from shop
- [x] Update items in shop

**Auction**
- [x] Create auctions
- [x] View and bet in auctions
- [x] Add items to auctions
- [x] Remove items in auctions
- [x] Update items in auctions